### PR TITLE
Update basic.c

### DIFF
--- a/samples/basic/basic.c
+++ b/samples/basic/basic.c
@@ -8,7 +8,7 @@
   Feel free to check the library code and come up with your own.
 
 */
-
+#include <kos.h>
 #include <stdio.h>
 #include <dreamroq/dreamroqlib.h>
 


### PR DESCRIPTION
Missing header   warning: implicit declaration of function 'pvr_init_defaults' fixed warning